### PR TITLE
feat(subcommands): improvements and consistencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"@favware/cliff-jumper": "^1.5.1",
 		"@favware/npm-deprecate": "^1.0.4",
 		"@sapphire/eslint-config": "^4.3.4",
-		"@sapphire/framework": "^2.4.1",
+		"@sapphire/framework": "next",
 		"@sapphire/pieces": "^3.3.1",
 		"@sapphire/prettier-config": "^1.4.3",
 		"@sapphire/stopwatch": "^1.4.1",

--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -88,6 +88,7 @@ export class SubCommandPluginCommand extends Command {
 		const result = await fromAsync(async () => {
 			interaction.client.emit(Events.ChatInputSubcommandRun, interaction, subcommand, payload);
 			let result: unknown;
+			subcommand.type ??= 'method';
 
 			if (subcommand.type === 'command') {
 				const command = await this.container.stores.get('commands').get(subcommand.name);
@@ -124,6 +125,7 @@ export class SubCommandPluginCommand extends Command {
 		const result = await fromAsync(async () => {
 			message.client.emit(Events.MessageSubcommandRun, message, subcommand, payload);
 			let result: unknown;
+			subcommand.type ??= 'method';
 
 			if (subcommand.type === 'command') {
 				const command = await this.container.stores.get('commands').get(subcommand.name);

--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -98,14 +98,14 @@ export class SubCommandPluginCommand extends Command {
 						.get('preconditions')
 						.chatInputRun(interaction, command as ChatInputCommand, context as any);
 					if (!globalResult.success) {
-						this.container.client.emit(Events.ChatInputSubcommandDenied, globalResult.error, payload);
+						this.container.client.emit(Events.ChatInputSubcommandDenied, globalResult.error, { ...payload, subcommand });
 						return;
 					}
 
 					// Run command-specific preconditions:
 					const localResult = await command.preconditions.chatInputRun(interaction, command as ChatInputCommand, context as any);
 					if (!localResult.success) {
-						this.container.client.emit(Events.ChatInputSubcommandDenied, localResult.error, payload);
+						this.container.client.emit(Events.ChatInputSubcommandDenied, localResult.error, { ...payload, subcommand });
 						return;
 					}
 
@@ -156,14 +156,14 @@ export class SubCommandPluginCommand extends Command {
 						.get('preconditions')
 						.messageRun(message, command as MessageCommand, payload as any);
 					if (!globalResult.success) {
-						this.container.client.emit(Events.MessageSubcommandDenied, globalResult.error, { ...payload, parameters });
+						this.container.client.emit(Events.MessageSubcommandDenied, globalResult.error, { ...payload, parameters, subcommand });
 						return;
 					}
 
 					// Run command-specific preconditions:
 					const localResult = await command.preconditions.messageRun(message, command as MessageCommand, context as any);
 					if (!localResult.success) {
-						this.container.client.emit(Events.MessageSubcommandDenied, localResult.error, { ...payload, parameters });
+						this.container.client.emit(Events.MessageSubcommandDenied, localResult.error, { ...payload, parameters, subcommand });
 						return;
 					}
 

--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -177,7 +177,7 @@ export class SubCommandPluginCommand extends Command {
 				if (typeof subcommand.to === 'string') {
 					const method = Reflect.get(this, subcommand.to) as MessageSubcommandToProperty | undefined;
 					if (method) {
-						result = await await Reflect.apply(method, this, [message, args, context]);
+						result = await Reflect.apply(method, this, [message, args, context]);
 					} else {
 						err(new UserError({ identifier: Identifiers.SubcommandNotFound, context: { ...payload } }));
 					}

--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -98,7 +98,7 @@ export class SubCommandPluginCommand extends Command {
 				err(new UserError({ identifier: Identifiers.SubcommandNotFound, context: { ...payload } }));
 			}
 
-			if (subcommand.type === 'method') {
+			if (subcommand.type === 'method' && subcommand.to) {
 				if (typeof subcommand.to === 'string') {
 					const method = Reflect.get(this, subcommand.to) as ChatInputSubcommandToProperty | undefined;
 					if (method) {
@@ -134,7 +134,7 @@ export class SubCommandPluginCommand extends Command {
 				err(new UserError({ identifier: Identifiers.SubcommandNotFound, context: { ...payload } }));
 			}
 
-			if (subcommand.type === 'method') {
+			if (subcommand.type === 'method' && subcommand.to) {
 				if (typeof subcommand.to === 'string') {
 					const method = Reflect.get(this, subcommand.to) as MessageSubcommandToProperty | undefined;
 					if (method) {

--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -3,44 +3,45 @@ import {
 	isErr,
 	type Args,
 	Command,
-	type MessageCommandContext,
 	type PieceContext,
 	ChatInputCommand,
 	err,
 	UserError,
-	Identifiers
+	Identifiers,
+	Awaitable,
+	MessageCommand
 } from '@sapphire/framework';
-import type { CommandInteraction, Message } from 'discord.js';
+import type { Message } from 'discord.js';
 import {
-	SubCommandMessageRunMappingValue,
-	SubcommandMessageRunMappings,
-	type SubcommandMappingsArray,
 	ChatInputSubcommandMappings,
-	SubCommandMappingValue,
 	ChatInputSubcommandGroupMappings,
-	SubCommandInteractionToProperty,
-	SubCommandMessageToProperty
+	ChatInputSubcommandMappingValue,
+	ChatInputSubcommandToProperty,
+	MessageSubcommandMappings,
+	MessageSubcommandMappingValue,
+	MessageSubcommandToProperty,
+	type SubcommandMappingsArray
 } from './SubcommandMappings';
-import { Events } from './types/Events';
+import { ChatInputSubcommandAcceptedPayload, Events, MessageSubcommandAcceptedPayload } from './types/Events';
 
 export class SubCommandPluginCommand extends Command {
-	public readonly subCommands: SubcommandMappingsArray;
+	public readonly subcommands: SubcommandMappingsArray;
 
-	public constructor(context: PieceContext, options: SubCommandPluginCommandOptions) {
+	public constructor(context: PieceContext, options: SubcommandPluginCommandOptions) {
 		super(context, options);
-		this.subCommands = options.subCommands ?? [];
+		this.subcommands = options.subcommands ?? [];
 	}
 
-	public messageRun(message: Message, args: Args, context: MessageCommandContext) {
+	public messageRun(message: Message, args: Args, context: MessageCommand.RunContext): Awaitable<unknown> {
 		args.save();
 		const value = args.nextMaybe();
-		let defaultCommmand: SubCommandMessageRunMappingValue | null = null;
+		let defaultCommmand: MessageSubcommandMappingValue | null = null;
 
-		for (const mapping of this.subCommands) {
-			if (!(mapping instanceof SubcommandMessageRunMappings)) continue;
+		for (const mapping of this.subcommands) {
+			if (!(mapping instanceof MessageSubcommandMappings)) continue;
 			defaultCommmand = mapping.subcommands.find((s) => s.default === true) ?? null;
-			const subCommand = mapping.subcommands.find(({ name }) => name === value.value);
-			if (subCommand) return this.#handleMessageRun(message, args, context, subCommand);
+			const subcommand = mapping.subcommands.find(({ name }) => name === value.value);
+			if (subcommand) return this.#handleMessageRun(message, args, context, subcommand);
 		}
 
 		// No subcommand matched, let's restore and try to run default, if any:
@@ -48,82 +49,91 @@ export class SubCommandPluginCommand extends Command {
 		if (defaultCommmand) return this.#handleMessageRun(message, args, context, defaultCommmand);
 
 		// No match and no subcommand, return an err:
-		return err(new UserError({ identifier: Identifiers.SubCommandMessageNoMatch, context }));
+		return err(new UserError({ identifier: Identifiers.MessageSubcommandNoMatch, context }));
 	}
 
-	public chatInputRun(interaction: CommandInteraction, context: ChatInputCommand.RunContext) {
-		const subCommandName = interaction.options.getSubcommand(false);
-		const subCommandGroupName = interaction.options.getSubcommandGroup(false);
+	public chatInputRun(interaction: ChatInputCommand.Interaction, context: ChatInputCommand.RunContext): Awaitable<unknown> {
+		const subcommandName = interaction.options.getSubcommand(false);
+		const subcommandGroupName = interaction.options.getSubcommandGroup(false);
 
-		if (subCommandName && !subCommandGroupName) {
-			for (const mapping of this.subCommands) {
+		if (subcommandName && !subcommandGroupName) {
+			for (const mapping of this.subcommands) {
 				if (!(mapping instanceof ChatInputSubcommandMappings)) continue;
 
-				const subCommand = mapping.subcommands.find(({ name }) => name === subCommandName);
-				if (subCommand) return this.#handleInteractionRun(interaction, context, subCommand);
+				const subcommand = mapping.subcommands.find(({ name }) => name === subcommandName);
+				if (subcommand) return this.#handleInteractionRun(interaction, context, subcommand);
 			}
 		}
 
-		if (subCommandGroupName) {
-			for (const mapping of this.subCommands) {
+		if (subcommandGroupName) {
+			for (const mapping of this.subcommands) {
 				if (!(mapping instanceof ChatInputSubcommandGroupMappings)) continue;
-				if (mapping.groupName !== subCommandGroupName) continue;
+				if (mapping.groupName !== subcommandGroupName) continue;
 
-				const subCommand = mapping.subcommands.find(({ name }) => name === subCommandName);
-				if (subCommand) return this.#handleInteractionRun(interaction, context, subCommand);
+				const subcommand = mapping.subcommands.find(({ name }) => name === subcommandName);
+				if (subcommand) return this.#handleInteractionRun(interaction, context, subcommand);
 			}
 		}
 
 		// No match and no subcommand, return an err:
-		return err(new UserError({ identifier: Identifiers.SubCommandInteractionNoMatch, context }));
+		return err(new UserError({ identifier: Identifiers.ChatInputSubcommandNoMatch, context }));
 	}
 
-	async #handleInteractionRun(interaction: CommandInteraction, context: ChatInputCommand.RunContext, subCommand: SubCommandMappingValue) {
+	async #handleInteractionRun(
+		interaction: ChatInputCommand.Interaction,
+		context: ChatInputCommand.RunContext,
+		subcommand: ChatInputSubcommandMappingValue
+	) {
+		const payload: ChatInputSubcommandAcceptedPayload = { command: this, context, interaction };
 		const result = await fromAsync(async () => {
-			interaction.client.emit(Events.SubCommandMessageRun as never, interaction, subCommand, context);
-			if (typeof subCommand.to === 'string') {
-				const method = Reflect.get(this, subCommand.to) as SubCommandInteractionToProperty | undefined;
+			interaction.client.emit(Events.ChatInputSubcommandRun, interaction, subcommand, payload);
+			let result: unknown;
+
+			if (typeof subcommand.to === 'string') {
+				const method = Reflect.get(this, subcommand.to) as ChatInputSubcommandToProperty | undefined;
 				if (method) {
-					await method(interaction, context);
+					result = await Reflect.apply(method, this, [interaction, context]);
 				} else {
-					err(new UserError({ identifier: Identifiers.SubCommandMethodNotFound, context }));
+					err(new UserError({ identifier: Identifiers.SubcommandMethodNotFound, context: { ...payload } }));
 				}
 			} else {
-				await subCommand.to(interaction, context);
+				result = await subcommand.to(interaction, context);
 			}
 
-			interaction.client.emit(Events.SubCommandMessageSuccess as never, interaction, subCommand, context);
+			interaction.client.emit(Events.ChatInputSubcommandSuccess, interaction, subcommand, { ...payload, result });
 		});
 
 		if (isErr(result)) {
-			interaction.client.emit(Events.SubCommandMessageSuccess as never, result.error, context);
+			interaction.client.emit(Events.SubcommandError, result.error, payload);
 		}
 	}
 
-	async #handleMessageRun(message: Message, args: Args, context: MessageCommandContext, subCommand: SubCommandMessageRunMappingValue) {
+	async #handleMessageRun(message: Message, args: Args, context: MessageCommand.RunContext, subcommand: MessageSubcommandMappingValue) {
+		const payload: MessageSubcommandAcceptedPayload = { message, command: this, context };
 		const result = await fromAsync(async () => {
-			message.client.emit(Events.SubCommandMessageRun as never, message, subCommand, context);
+			message.client.emit(Events.MessageSubcommandRun, message, subcommand, payload);
+			let result: unknown;
 
-			if (typeof subCommand.to === 'string') {
-				const method = Reflect.get(this, subCommand.to) as SubCommandMessageToProperty | undefined;
+			if (typeof subcommand.to === 'string') {
+				const method = Reflect.get(this, subcommand.to) as MessageSubcommandToProperty | undefined;
 				if (method) {
-					await method(message, args, context);
+					result = await await Reflect.apply(method, this, [message, args, context]);
 				} else {
-					err(new UserError({ identifier: Identifiers.SubCommandMethodNotFound, context }));
+					err(new UserError({ identifier: Identifiers.SubcommandMethodNotFound, context: { ...payload } }));
 				}
 			} else {
-				await subCommand.to(message, args, context);
+				result = await subcommand.to(message, args, context);
 			}
 
-			message.client.emit(Events.SubCommandMessageSuccess as never, message, subCommand, context);
+			message.client.emit(Events.MessageSubcommandSuccess, message, subcommand, { ...payload, result });
 		});
 
 		if (isErr(result)) {
-			message.client.emit(Events.SubCommandMessageSuccess as never, result.error, context);
+			message.client.emit(Events.SubcommandError, result.error, payload);
 		}
 	}
 }
 
-export interface SubCommandPluginCommandOptions extends Command.Options {
-	subCommands?: SubcommandMappingsArray;
+export interface SubcommandPluginCommandOptions extends Command.Options {
+	subcommands?: SubcommandMappingsArray;
 }

--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -9,8 +9,7 @@ import {
 	UserError,
 	Identifiers,
 	Awaitable,
-	MessageCommand,
-	Events as SapphireEvents
+	MessageCommand
 } from '@sapphire/framework';
 import type { Message } from 'discord.js';
 import {
@@ -99,14 +98,14 @@ export class SubCommandPluginCommand extends Command {
 						.get('preconditions')
 						.chatInputRun(interaction, command as ChatInputCommand, context as any);
 					if (!globalResult.success) {
-						this.container.client.emit(SapphireEvents.ChatInputCommandDenied, globalResult.error, payload);
+						this.container.client.emit(Events.ChatInputSubcommandDenied, globalResult.error, payload);
 						return;
 					}
 
 					// Run command-specific preconditions:
 					const localResult = await command.preconditions.chatInputRun(interaction, command as ChatInputCommand, context as any);
 					if (!localResult.success) {
-						this.container.client.emit(SapphireEvents.ChatInputCommandDenied, localResult.error, payload);
+						this.container.client.emit(Events.ChatInputSubcommandDenied, localResult.error, payload);
 						return;
 					}
 
@@ -157,14 +156,14 @@ export class SubCommandPluginCommand extends Command {
 						.get('preconditions')
 						.messageRun(message, command as MessageCommand, payload as any);
 					if (!globalResult.success) {
-						message.client.emit(SapphireEvents.MessageCommandDenied, globalResult.error, { ...payload, parameters });
+						this.container.client.emit(Events.MessageSubcommandDenied, globalResult.error, { ...payload, parameters });
 						return;
 					}
 
 					// Run command-specific preconditions:
-					const localResult = await command.preconditions.messageRun(message, command as MessageCommand, payload as any);
+					const localResult = await command.preconditions.messageRun(message, command as MessageCommand, context as any);
 					if (!localResult.success) {
-						message.client.emit(SapphireEvents.MessageCommandDenied, localResult.error, { ...payload, parameters });
+						this.container.client.emit(Events.MessageSubcommandDenied, localResult.error, { ...payload, parameters });
 						return;
 					}
 

--- a/packages/subcommands/src/lib/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/SubcommandMappings.ts
@@ -69,7 +69,7 @@ export interface ChatInputSubcommandMappingValue {
 	 *
 	 * @since 3.0.0
 	 */
-	to: ChatInputSubcommandToProperty | string;
+	to?: ChatInputSubcommandToProperty | string;
 
 	/**
 	 * Select whether you want to execute a command class method or a command registered in the store.
@@ -84,7 +84,7 @@ export interface MessageSubcommandMappingValue extends Omit<ChatInputSubcommandM
 	 *
 	 * @since 3.0.0
 	 */
-	to: MessageSubcommandToProperty | string;
+	to?: MessageSubcommandToProperty | string;
 
 	/**
 	 * Should this command be ran if no input is given

--- a/packages/subcommands/src/lib/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/SubcommandMappings.ts
@@ -75,7 +75,7 @@ export interface ChatInputSubcommandMappingValue {
 	 * Select whether you want to execute a command class method or a command registered in the store.
 	 * @since 3.0.0
 	 */
-	type: SubcommandType;
+	type?: SubcommandType;
 }
 
 export interface MessageSubcommandMappingValue extends Omit<ChatInputSubcommandMappingValue, 'to'> {

--- a/packages/subcommands/src/lib/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/SubcommandMappings.ts
@@ -4,6 +4,7 @@ import type { Message } from 'discord.js';
 export type SubcommandMappingsArray = (ChatInputSubcommandGroupMappings | ChatInputSubcommandMappings | MessageSubcommandMappings)[];
 export type ChatInputSubcommandToProperty = (interaction: ChatInputCommand.Interaction, context: ChatInputCommand.RunContext) => Awaitable<unknown>;
 export type MessageSubcommandToProperty = (message: Message, args: Args, context: MessageCommand.RunContext) => Awaitable<unknown>;
+export type SubCommandType = 'method' | 'command';
 export class ChatInputSubcommandGroupMappings {
 	/**
 	 * Name of the subcommand group
@@ -71,11 +72,10 @@ export interface ChatInputSubcommandMappingValue {
 	to: ChatInputSubcommandToProperty | string;
 
 	/**
-	 * Should this command be ran if no input is given
-	 *
+	 * Select whether you want to execute a command class method or a command registered in the store.
 	 * @since 3.0.0
 	 */
-	default?: boolean;
+	type: SubCommandType;
 }
 
 export interface MessageSubcommandMappingValue extends Omit<ChatInputSubcommandMappingValue, 'to'> {
@@ -85,4 +85,11 @@ export interface MessageSubcommandMappingValue extends Omit<ChatInputSubcommandM
 	 * @since 3.0.0
 	 */
 	to: MessageSubcommandToProperty | string;
+
+	/**
+	 * Should this command be ran if no input is given
+	 *
+	 * @since 3.0.0
+	 */
+	default?: boolean;
 }

--- a/packages/subcommands/src/lib/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/SubcommandMappings.ts
@@ -1,9 +1,9 @@
-import type { Args, Awaitable, ChatInputCommand, MessageCommandContext } from '@sapphire/framework';
-import type { CommandInteraction, Message } from 'discord.js';
+import type { Args, Awaitable, ChatInputCommand, MessageCommand } from '@sapphire/framework';
+import type { Message } from 'discord.js';
 
-export type SubcommandMappingsArray = (SubCommandMappingValue | ChatInputSubcommandMappings | SubcommandMessageRunMappings)[];
-export type SubCommandInteractionToProperty = (interaction: CommandInteraction, context: ChatInputCommand.RunContext) => Awaitable<unknown>;
-export type SubCommandMessageToProperty = (message: Message, args: Args, context: MessageCommandContext) => Awaitable<unknown>;
+export type SubcommandMappingsArray = (ChatInputSubcommandGroupMappings | ChatInputSubcommandMappings | MessageSubcommandMappings)[];
+export type ChatInputSubcommandToProperty = (interaction: ChatInputCommand.Interaction, context: ChatInputCommand.RunContext) => Awaitable<unknown>;
+export type MessageSubcommandToProperty = (message: Message, args: Args, context: MessageCommand.RunContext) => Awaitable<unknown>;
 export class ChatInputSubcommandGroupMappings {
 	/**
 	 * Name of the subcommand group
@@ -17,9 +17,9 @@ export class ChatInputSubcommandGroupMappings {
 	 * /config   mod-roles  add         role
 	 * command   group      subcommand  option
 	 */
-	public subcommands: SubCommandMappingValue[];
+	public subcommands: ChatInputSubcommandMappingValue[];
 
-	public constructor(groupName: string, mappings: SubCommandMappingValue[]) {
+	public constructor(groupName: string, mappings: ChatInputSubcommandMappingValue[]) {
 		this.groupName = groupName;
 		this.subcommands = mappings;
 	}
@@ -33,14 +33,14 @@ export class ChatInputSubcommandMappings {
 	 * /config  language   en-US
 	 *          command    subcommand option
 	 */
-	public subcommands: SubCommandMappingValue[];
+	public subcommands: ChatInputSubcommandMappingValue[];
 
-	public constructor(subcommands: SubCommandMappingValue[]) {
+	public constructor(subcommands: ChatInputSubcommandMappingValue[]) {
 		this.subcommands = subcommands;
 	}
 }
 
-export class SubcommandMessageRunMappings {
+export class MessageSubcommandMappings {
 	/**
 	 * Subcommands for this Command
 	 *
@@ -48,14 +48,14 @@ export class SubcommandMessageRunMappings {
 	 * /config  language   en-US
 	 *          command    subcommand option
 	 */
-	public subcommands: SubCommandMessageRunMappingValue[];
+	public subcommands: MessageSubcommandMappingValue[];
 
-	public constructor(subcommands: SubCommandMessageRunMappingValue[]) {
+	public constructor(subcommands: MessageSubcommandMappingValue[]) {
 		this.subcommands = subcommands;
 	}
 }
 
-export interface SubCommandMappingValue {
+export interface ChatInputSubcommandMappingValue {
 	/**
 	 * Name of the Subcommand
 	 *
@@ -68,7 +68,7 @@ export interface SubCommandMappingValue {
 	 *
 	 * @since 3.0.0
 	 */
-	to: SubCommandInteractionToProperty | string;
+	to: ChatInputSubcommandToProperty | string;
 
 	/**
 	 * Should this command be ran if no input is given
@@ -78,11 +78,11 @@ export interface SubCommandMappingValue {
 	default?: boolean;
 }
 
-export interface SubCommandMessageRunMappingValue extends Omit<SubCommandMappingValue, 'to'> {
+export interface MessageSubcommandMappingValue extends Omit<ChatInputSubcommandMappingValue, 'to'> {
 	/**
 	 * The method or name used used to run the subcommand
 	 *
 	 * @since 3.0.0
 	 */
-	to: SubCommandMessageToProperty | string;
+	to: MessageSubcommandToProperty | string;
 }

--- a/packages/subcommands/src/lib/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/SubcommandMappings.ts
@@ -75,7 +75,7 @@ export interface ChatInputSubcommandMappingValue {
 	 * Select whether you want to execute a command class method or a command registered in the store.
 	 * @since 3.0.0
 	 */
-	type: SubCommandType;
+	type: SubcommandType;
 }
 
 export interface MessageSubcommandMappingValue extends Omit<ChatInputSubcommandMappingValue, 'to'> {

--- a/packages/subcommands/src/lib/SubcommandMappings.ts
+++ b/packages/subcommands/src/lib/SubcommandMappings.ts
@@ -4,7 +4,7 @@ import type { Message } from 'discord.js';
 export type SubcommandMappingsArray = (ChatInputSubcommandGroupMappings | ChatInputSubcommandMappings | MessageSubcommandMappings)[];
 export type ChatInputSubcommandToProperty = (interaction: ChatInputCommand.Interaction, context: ChatInputCommand.RunContext) => Awaitable<unknown>;
 export type MessageSubcommandToProperty = (message: Message, args: Args, context: MessageCommand.RunContext) => Awaitable<unknown>;
-export type SubCommandType = 'method' | 'command';
+export type SubcommandType = 'method' | 'command';
 export class ChatInputSubcommandGroupMappings {
 	/**
 	 * Name of the subcommand group

--- a/packages/subcommands/src/lib/types/Events.ts
+++ b/packages/subcommands/src/lib/types/Events.ts
@@ -1,4 +1,4 @@
-import type { ChatInputCommand, MessageCommand } from '@sapphire/framework';
+import type { ChatInputCommand, MessageCommand, UserError } from '@sapphire/framework';
 import type { Message } from 'discord.js';
 import type { ChatInputSubcommandMappingValue, MessageSubcommandMappingValue } from '../SubcommandMappings';
 
@@ -7,9 +7,11 @@ export const Events = {
 	ChatInputSubcommandRun: 'chatInputSubcommandRun' as const,
 	ChatInputSubcommandSuccess: 'chatInputSubcommandSuccess' as const,
 	ChatInputSubcommandNotFound: 'chatInputSubcommandNotFound' as const,
+	ChatInputSubcommandDenied: 'chatInputSubcommandDenied' as const,
 	MessageSubcommandRun: 'messageSubcommandRun' as const,
 	MessageSubcommandSuccess: 'messageSubcommandSuccess' as const,
-	MessageSubcommandNotFound: 'messageSubcommandNotFound' as const
+	MessageSubcommandNotFound: 'messageSubcommandNotFound' as const,
+	MessageSubcommandDenied: 'messageSubcommandDenied' as const
 };
 
 export interface IMessageSubcommandPayload {
@@ -24,6 +26,10 @@ export interface MessageSubcommandAcceptedPayload extends IMessageSubcommandPayl
 export interface MessageSubcommandRunPayload extends MessageSubcommandAcceptedPayload {}
 
 export interface MessageSubcommandErrorPayload extends MessageSubcommandRunPayload {}
+
+export interface MessageSubcommandDeniedPayload extends MessageSubcommandRunPayload {
+	parameters: string;
+}
 
 export interface MessageSubcommandSuccessPayload extends MessageSubcommandRunPayload {
 	result: unknown;
@@ -41,6 +47,8 @@ export interface ChatInputSubcommandAcceptedPayload extends IChatInputSubcommand
 export interface ChatInputSubcommandRunPayload extends ChatInputSubcommandAcceptedPayload {}
 
 export interface ChatInputSubcommandErrorPayload extends ChatInputSubcommandRunPayload {}
+
+export interface ChatInputSubcommandDeniedPayload extends ChatInputSubcommandRunPayload {}
 
 export interface ChatInputSubcommandSuccessPayload extends ChatInputSubcommandRunPayload {
 	result: unknown;
@@ -63,9 +71,11 @@ declare module 'discord.js' {
 			subcommand: ChatInputSubcommandMappingValue,
 			context: ChatInputCommand.Context
 		];
+		[Events.ChatInputSubcommandDenied]: [error: UserError, payload: ChatInputSubcommandDeniedPayload];
 		[Events.MessageSubcommandRun]: [message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandRunPayload];
 		[Events.MessageSubcommandSuccess]: [message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandSuccessPayload];
 		[Events.MessageSubcommandNotFound]: [message: Message, subcommand: MessageSubcommandMappingValue, context: ChatInputCommand.Context];
+		[Events.MessageSubcommandDenied]: [error: UserError, payload: MessageSubcommandDeniedPayload];
 		[Events.SubcommandError]: [error: unknown, payload: ChatInputSubcommandErrorPayload | MessageSubcommandErrorPayload];
 	}
 }

--- a/packages/subcommands/src/lib/types/Events.ts
+++ b/packages/subcommands/src/lib/types/Events.ts
@@ -72,8 +72,8 @@ declare module 'discord.js' {
 
 declare module '@sapphire/framework' {
 	const enum Identifiers {
-		MessageSubcommandNoMatch = 'MessageSubcommandNoMatch',
-		ChatInputSubcommandNoMatch = 'ChatInputSubcommandNoMatch',
+		MessageSubcommandNoMatch = 'messageSubcommandNoMatch',
+		ChatInputSubcommandNoMatch = 'chatInputSubcommandNoMatch',
 		SubcommandMethodNotFound = 'subcommandMethodNotFound'
 	}
 }

--- a/packages/subcommands/src/lib/types/Events.ts
+++ b/packages/subcommands/src/lib/types/Events.ts
@@ -1,36 +1,79 @@
-import type { ChatInputCommand, ChatInputCommandContext, MessageCommand } from '@sapphire/framework';
-import type { SubCommandMappingValue, SubCommandMessageRunMappingValue } from '../SubcommandMappings';
+import type { ChatInputCommand, MessageCommand } from '@sapphire/framework';
+import type { Message } from 'discord.js';
+import type { ChatInputSubcommandMappingValue, MessageSubcommandMappingValue } from '../SubcommandMappings';
 
 export const Events = {
-	SubCommandError: 'subcommandError' as const,
-	SubCommandInteractionRun: 'subcommandInteractionRun' as const,
-	SubCommandInteractionSuccess: 'subcommandInteractionSuccess' as const,
-	subCommandInteractionNotFound: 'subcommandInteractionNotFound' as const,
-	SubCommandMessageRun: 'subcommandMessageRun' as const,
-	SubCommandMessageSuccess: 'subcommandMessageSuccess' as const,
-	subCommandMessageNotFound: 'subCommandMessageNotFound' as const
+	SubcommandError: 'subcommandError' as const,
+	ChatInputSubcommandRun: 'chatInputSubcommandRun' as const,
+	ChatInputSubcommandSuccess: 'chatInputSubcommandSuccess' as const,
+	ChatInputSubcommandNotFound: 'chatInputSubcommandNotFound' as const,
+	MessageSubcommandRun: 'messageSubcommandRun' as const,
+	MessageSubcommandSuccess: 'messageSubcommandSuccess' as const,
+	MessageSubcommandNotFound: 'messageSubcommandNotFound' as const
 };
+
+export interface IMessageSubcommandPayload {
+	message: Message;
+	command: MessageCommand;
+}
+
+export interface MessageSubcommandAcceptedPayload extends IMessageSubcommandPayload {
+	context: MessageCommand.RunContext;
+}
+
+export interface MessageSubcommandRunPayload extends MessageSubcommandAcceptedPayload {}
+
+export interface MessageSubcommandErrorPayload extends MessageSubcommandRunPayload {}
+
+export interface MessageSubcommandSuccessPayload extends MessageSubcommandRunPayload {
+	result: unknown;
+}
+
+export interface IChatInputSubcommandPayload {
+	interaction: ChatInputCommand.Interaction;
+	command: ChatInputCommand;
+}
+
+export interface ChatInputSubcommandAcceptedPayload extends IChatInputSubcommandPayload {
+	context: ChatInputCommand.RunContext;
+}
+
+export interface ChatInputSubcommandRunPayload extends ChatInputSubcommandAcceptedPayload {}
+
+export interface ChatInputSubcommandErrorPayload extends ChatInputSubcommandRunPayload {}
+
+export interface ChatInputSubcommandSuccessPayload extends ChatInputSubcommandRunPayload {
+	result: unknown;
+}
 
 declare module 'discord.js' {
 	interface ClientEvents {
-		[Events.SubCommandInteractionRun]: [interaction: Interaction, subcommand: SubCommandMappingValue, context: ChatInputCommand.Context];
-		[Events.SubCommandInteractionSuccess]: [interaction: Interaction, subCommand: SubCommandMappingValue, context: ChatInputCommandContext];
-		[Events.subCommandInteractionNotFound]: [interaction: Interaction, subcommand: SubCommandMappingValue, context: ChatInputCommand.Context];
-		[Events.SubCommandMessageRun]: [Message: Message, subcommand: SubCommandMessageRunMappingValue, context: MessageCommand.Context];
-		[Events.SubCommandMessageSuccess]: [Message: Message, subcommand: SubCommandMessageRunMappingValue, context: MessageCommand.Context];
-		[Events.subCommandMessageNotFound]: [
+		[Events.ChatInputSubcommandRun]: [
 			interaction: Interaction,
-			subcommand: SubCommandMessageRunMappingValue,
+			subcommand: ChatInputSubcommandMappingValue,
+			payload: ChatInputSubcommandRunPayload
+		];
+		[Events.ChatInputSubcommandSuccess]: [
+			interaction: Interaction,
+			subcommand: ChatInputSubcommandMappingValue,
+			payload: ChatInputSubcommandSuccessPayload
+		];
+		[Events.ChatInputSubcommandNotFound]: [
+			interaction: Interaction,
+			subcommand: ChatInputSubcommandMappingValue,
 			context: ChatInputCommand.Context
 		];
-		[Events.SubCommandError]: [error: unknown, payload: ChatInputCommand.RunContext | MessageCommand.Context];
+		[Events.MessageSubcommandRun]: [Message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandRunPayload];
+		[Events.MessageSubcommandSuccess]: [Message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandSuccessPayload];
+		[Events.MessageSubcommandNotFound]: [interaction: Interaction, subcommand: MessageSubcommandMappingValue, context: ChatInputCommand.Context];
+		[Events.SubcommandError]: [error: unknown, payload: ChatInputSubcommandErrorPayload | MessageSubcommandErrorPayload];
 	}
 }
 
 declare module '@sapphire/framework' {
-	enum Identifiers {
-		SubCommandMessageNoMatch = 'subCommandMessageNoMatch',
-		SubCommandInteractionNoMatch = 'subCommandInteractionNoMatch',
-		SubCommandMethodNotFound = 'subCommandMethodNotFound'
+	const enum Identifiers {
+		MessageSubcommandNoMatch = 'MessageSubcommandNoMatch',
+		ChatInputSubcommandNoMatch = 'ChatInputSubcommandNoMatch',
+		SubcommandMethodNotFound = 'subcommandMethodNotFound'
 	}
 }

--- a/packages/subcommands/src/lib/types/Events.ts
+++ b/packages/subcommands/src/lib/types/Events.ts
@@ -29,6 +29,7 @@ export interface MessageSubcommandErrorPayload extends MessageSubcommandRunPaylo
 
 export interface MessageSubcommandDeniedPayload extends MessageSubcommandRunPayload {
 	parameters: string;
+	subcommand: MessageSubcommandMappingValue;
 }
 
 export interface MessageSubcommandSuccessPayload extends MessageSubcommandRunPayload {
@@ -48,7 +49,9 @@ export interface ChatInputSubcommandRunPayload extends ChatInputSubcommandAccept
 
 export interface ChatInputSubcommandErrorPayload extends ChatInputSubcommandRunPayload {}
 
-export interface ChatInputSubcommandDeniedPayload extends ChatInputSubcommandRunPayload {}
+export interface ChatInputSubcommandDeniedPayload extends ChatInputSubcommandRunPayload {
+	subcommand: ChatInputSubcommandMappingValue;
+}
 
 export interface ChatInputSubcommandSuccessPayload extends ChatInputSubcommandRunPayload {
 	result: unknown;

--- a/packages/subcommands/src/lib/types/Events.ts
+++ b/packages/subcommands/src/lib/types/Events.ts
@@ -74,6 +74,6 @@ declare module '@sapphire/framework' {
 	const enum Identifiers {
 		MessageSubcommandNoMatch = 'messageSubcommandNoMatch',
 		ChatInputSubcommandNoMatch = 'chatInputSubcommandNoMatch',
-		SubcommandMethodNotFound = 'subcommandMethodNotFound'
+		SubcommandNotFound = 'subcommandNotFound'
 	}
 }

--- a/packages/subcommands/src/lib/types/Events.ts
+++ b/packages/subcommands/src/lib/types/Events.ts
@@ -63,9 +63,9 @@ declare module 'discord.js' {
 			subcommand: ChatInputSubcommandMappingValue,
 			context: ChatInputCommand.Context
 		];
-		[Events.MessageSubcommandRun]: [Message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandRunPayload];
-		[Events.MessageSubcommandSuccess]: [Message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandSuccessPayload];
-		[Events.MessageSubcommandNotFound]: [interaction: Interaction, subcommand: MessageSubcommandMappingValue, context: ChatInputCommand.Context];
+		[Events.MessageSubcommandRun]: [message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandRunPayload];
+		[Events.MessageSubcommandSuccess]: [message: Message, subcommand: MessageSubcommandMappingValue, payload: MessageSubcommandSuccessPayload];
+		[Events.MessageSubcommandNotFound]: [message: Message, subcommand: MessageSubcommandMappingValue, context: ChatInputCommand.Context];
 		[Events.SubcommandError]: [error: unknown, payload: ChatInputSubcommandErrorPayload | MessageSubcommandErrorPayload];
 	}
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,7 +1076,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/discord-utilities@npm:^2.10.3, @sapphire/discord-utilities@npm:^2.8.0":
+"@sapphire/discord-utilities@npm:^2.10.3":
   version: 2.10.3
   resolution: "@sapphire/discord-utilities@npm:2.10.3"
   dependencies:
@@ -1085,7 +1085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/discord.js-utilities@npm:^4.8.1":
+"@sapphire/discord.js-utilities@npm:^4.10.0":
   version: 4.10.0
   resolution: "@sapphire/discord.js-utilities@npm:4.10.0"
   dependencies:
@@ -1121,22 +1121,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/framework@npm:^2.4.1":
-  version: 2.4.1
-  resolution: "@sapphire/framework@npm:2.4.1"
+"@sapphire/framework@npm:next":
+  version: 3.0.0-next.8803fa8.0
+  resolution: "@sapphire/framework@npm:3.0.0-next.8803fa8.0"
   dependencies:
-    "@sapphire/discord-utilities": ^2.8.0
-    "@sapphire/discord.js-utilities": ^4.8.1
-    "@sapphire/pieces": ^3.2.0
-    "@sapphire/ratelimits": ^2.3.1
-    "@sapphire/utilities": ^3.3.0
+    "@sapphire/discord-utilities": ^2.10.3
+    "@sapphire/discord.js-utilities": ^4.10.0
+    "@sapphire/pieces": ^3.3.1
+    "@sapphire/ratelimits": ^2.4.4
+    "@sapphire/result": ^1.1.1
+    "@sapphire/stopwatch": ^1.4.1
+    "@sapphire/utilities": ^3.6.2
     lexure: ^0.17.0
-    tslib: ^2.3.1
-  checksum: e6a540de098be8d3141633ff8aa88e1b4fa6bc2bd7e03a4402879dafa5e6e9e03e7b029f060ca257c592bb0c430118eaa2a6a9bd176b4efe584e12bcd492837a
+    tslib: ^2.4.0
+  checksum: 23c8177d5817f54098011b48919c858c4cca6564bd7e0dca16616b074b8ecfe0545579a87b214f5c8fbf4dcacef73e55a18b9be4e888b9233bb3a518b2640b67
   languageName: node
   linkType: hard
 
-"@sapphire/pieces@npm:^3.2.0, @sapphire/pieces@npm:^3.3.1":
+"@sapphire/pieces@npm:^3.3.1":
   version: 3.3.1
   resolution: "@sapphire/pieces@npm:3.3.1"
   dependencies:
@@ -1254,7 +1256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/ratelimits@npm:^2.3.1":
+"@sapphire/ratelimits@npm:^2.4.4":
   version: 2.4.4
   resolution: "@sapphire/ratelimits@npm:2.4.4"
   dependencies:
@@ -1298,7 +1300,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sapphire/utilities@npm:^3.0.1, @sapphire/utilities@npm:^3.3.0, @sapphire/utilities@npm:^3.6.2":
+"@sapphire/utilities@npm:^3.0.1, @sapphire/utilities@npm:^3.6.2":
   version: 3.6.2
   resolution: "@sapphire/utilities@npm:3.6.2"
   checksum: 71210753b446f3f2835dd9d28fb10767f4c6f005b465eea179082d9f2c071acb7dcd2aebdf7c4974b26aad3ab2374a1dd168a66371b06bd65f248bbca4a90cda
@@ -6364,7 +6366,7 @@ __metadata:
     "@favware/cliff-jumper": ^1.5.1
     "@favware/npm-deprecate": ^1.0.4
     "@sapphire/eslint-config": ^4.3.4
-    "@sapphire/framework": ^2.4.1
+    "@sapphire/framework": next
     "@sapphire/pieces": ^3.3.1
     "@sapphire/prettier-config": ^1.4.3
     "@sapphire/stopwatch": ^1.4.1


### PR DESCRIPTION
## Changes

- Fixed `this` not being accessible in subcommand functions during runtime.
- There were inconsistencies between the usage of `SubCommand` and `Subcommand`, it seemed to make most sense for everything to use `Subcommand` to match how Discord.js and Discord's API docs formatted this, as well as how people seem to more commonly write the word subcommand. This does include 2 extra breaking changes for `SubCommandPluginCommand` -> `SubcommandPluginCommand` and `subCommands` -> `subcommands` in options.
- Converted the context sent to events to payloads to match framework.
- Names of events, types, etc. were renamed to also match the formatting in framework of `Message*` and `ChatInput*`.
- Some other fixes for incorrect event emits and typings