### PR TITLE
feat(subcommands): allow to execute commands that have a name different from the slash command

### DIFF
--- a/packages/subcommands/src/lib/Subcommand.ts
+++ b/packages/subcommands/src/lib/Subcommand.ts
@@ -91,7 +91,8 @@ export class SubCommandPluginCommand extends Command {
 			subcommand.type ??= 'method';
 
 			if (subcommand.type === 'command') {
-				const command = this.container.stores.get('commands').get(subcommand.name);
+				const parsedCommandName = subcommand.to && typeof subcommand.to === 'string' ? subcommand.to : subcommand.name;
+				const command = this.container.stores.get('commands').get(parsedCommandName);
 				if (command && command.chatInputRun) {
 					// Run global preconditions:
 					const globalResult = await this.container.stores
@@ -144,7 +145,8 @@ export class SubCommandPluginCommand extends Command {
 			subcommand.type ??= 'method';
 
 			if (subcommand.type === 'command') {
-				const command = this.container.stores.get('commands').get(subcommand.name);
+				const parsedCommandName = subcommand.to && typeof subcommand.to === 'string' ? subcommand.to : subcommand.name;
+				const command = this.container.stores.get('commands').get(parsedCommandName);
 
 				if (command && command.messageRun) {
 					const prefixLess = message.content.slice(context.commandPrefix.length).trim();


### PR DESCRIPTION
This change has an effect only on subcommand groups, for example:

We have the case that the subcommand we put it of type command (execute a command from the command store), but the name of the command has a name different from the name that the slash command has, this allows to execute a slash subcommand based on executing a command from the command store commands without the need for its name to be identical to the slash command.

Example
```diff
+ / subcommand make emoji (search in command store the name emoji)
- / subcommand emoji ? (the same as the subcommand group, but what if here I want to do something else?)
// Here there is a conflict, since the subcommand group looks for a command in the store with the name emoji and the subcommand also.
```